### PR TITLE
fix: deploy dir from build to dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d build"
+    "deploy": "gh-pages -d dist"
   },
   "dependencies": {
     "react": "^18.2.0",


### PR DESCRIPTION
# issue

# 説明
- ビルドされたファイルのパスが間違っていました

# 対応

# 動作確認

# チェックするべきポイント
